### PR TITLE
msm8610-common: Remove android ID for audit daemon

### DIFF
--- a/include/private/android_filesystem_config.h
+++ b/include/private/android_filesystem_config.h
@@ -78,8 +78,6 @@
 #define AID_LOGD          1036  /* log daemon */
 #define AID_SHARED_RELRO  1037  /* creator of shared GNU RELRO files */
 
-#define AID_AUDIT         1049  /* audit daemon */
-
 #define AID_SHELL         2000  /* adb and debug shell user */
 #define AID_CACHE         2001  /* cache access */
 #define AID_DIAG          2002  /* access to diagnostic resources */
@@ -189,8 +187,6 @@ static const struct android_id_info android_ids[] = {
     { "sdcard_all",    AID_SDCARD_ALL, },
     { "logd",          AID_LOGD, },
     { "shared_relro",  AID_SHARED_RELRO, },
-
-    { "audit",         AID_AUDIT, },
 
     { "shell",         AID_SHELL, },
     { "cache",         AID_CACHE, },


### PR DESCRIPTION
- http://review.cyanogenmod.org/#/c/115694 We don't need this!
